### PR TITLE
Add image generation feature with separate page

### DIFF
--- a/backend/img2img.json
+++ b/backend/img2img.json
@@ -1,0 +1,114 @@
+{
+    "1": {
+      "inputs": {
+        "ckpt_name": "animagineXL40_v4Opt.safetensors"
+      },
+      "class_type": "CheckpointLoaderSimple"
+    },
+    "2": {
+      "inputs": {
+        "image": "Nih 2 pose.png", 
+        "upload": "image"
+      },
+      "class_type": "LoadImage"
+    },
+    "3": {
+      "inputs": {
+        "pixels": [
+          "2",
+          0
+        ],
+        "vae": [
+          "1",
+          2
+        ]
+      },
+      "class_type": "VAEEncode"
+    },
+    "4": {
+      "inputs": {
+        "seed": 1038569982436677,
+        "steps": 20,
+        "cfg": 9,
+        "sampler_name": "dpm_2",
+        "scheduler": "beta",
+        "denoise": 1,
+        "model": [
+          "1",
+          0
+        ],
+        "positive": [
+          "7",
+          0
+        ],
+        "negative": [
+          "8",
+          0
+        ],
+        "latent_image": [
+          "3",
+          0
+        ]
+      },
+      "class_type": "KSampler"
+    },
+    "5": {
+      "inputs": {
+        "samples": [
+          "4",
+          0
+        ],
+        "vae": [
+          "1",
+          2
+        ]
+      },
+      "class_type": "VAEDecode"
+    },
+    "6": {
+      "inputs": {
+        "filename_prefix": "ComfyUI_img2img",
+        "images": [
+          "5",
+          0
+        ]
+      },
+      "class_type": "SaveImage"
+    },
+    "7": {
+      "inputs": {
+        "text": "A close-up portrait of a young character with long yellow hair, simple and flowing. The character wears a plain white oversized shirt with a subtle view of the black shirt underneath near the neckline. The focus is on the face, capturing natural features with soft lighting and minimal shadows. The art style reflects a clean, hand-drawn sketch aesthetic, inspired by the design from the reference, emphasizing simplicity and casualness. The background is minimal, ensuring full focus remains on the character's face and hair.",
+        "clip": [
+          "1",
+          1
+        ]
+      },
+      "class_type": "CLIPTextEncode"
+    },
+    "8": {
+      "inputs": {
+        "text": "modern, recent, old, oldest, cartoon, graphic, text, painting, crayon, graphite, abstract, glitch, deformed, mutated, ugly, disfigured, long body, lowres, bad anatomy, bad hands, missing fingers, extra digit, fewer digits, cropped, very displeasing, (worst quality, bad quality:1.2), sketch, jpeg artifacts, signature, watermark, username, censored, bar_censor, simple background, conjoined, ai-generated",
+        "clip": [
+          "1",
+          1
+        ]
+      },
+      "class_type": "CLIPTextEncode"
+    },
+    "9": {
+      "inputs": {
+        "width": 1024,
+        "height": 1024,
+        "batch_size": 1
+      },
+      "class_type": "EmptyLatentImage"
+    },
+    "10": {
+      "inputs": {
+        "lora_name": null,
+        "strength_model": 1,
+        "strength_clip": 1
+      },
+      "class_type": "LoraLoader"
+    }
+  }

--- a/backend/src/controllers/img-generation/comfyuiController.ts
+++ b/backend/src/controllers/img-generation/comfyuiController.ts
@@ -1,0 +1,55 @@
+// THIS WILL ONLY WORK WHEN I RUN COMFYUI ON MY LOCAL MACHINE
+// I WILL NEED TO RUN COMFYUI ON THE SERVER TO MAKE THIS WORK ! ! !
+// THEN HAVE API RAN OR SOME STUFF CYKA ! ! !
+
+/*
+import { Request, Response } from 'express';
+import { exec } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+
+const modelPath = path.join(__dirname, '../../../path/to/sd3_medium_incl_clips.safetensors');
+const workflowPath = path.join(__dirname, '../../../img2img.json');
+const outputDir = path.join(__dirname, '../../../generated_images');
+
+export const generateImage = async (req: Request, res: Response) => {
+  const { prompt } = req.body;
+
+  if (!prompt) {
+    return res.status(400).json({ error: 'Prompt is required' });
+  }
+
+  try {
+    // Update the workflow JSON with the new prompt
+    const workflow = JSON.parse(fs.readFileSync(workflowPath, 'utf-8'));
+    workflow['7'].inputs.text = prompt;
+
+    // Save the updated workflow to a temporary file
+    const tempWorkflowPath = path.join(outputDir, 'temp_workflow.json');
+    fs.writeFileSync(tempWorkflowPath, JSON.stringify(workflow, null, 2));
+
+    // Run ComfyUI with the updated workflow
+    exec(`comfyui --workflow ${tempWorkflowPath} --output ${outputDir}`, (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Error generating image: ${error.message}`);
+        return res.status(500).json({ error: 'Failed to generate image' });
+      }
+
+      // Find the generated image
+      const files = fs.readdirSync(outputDir);
+      const imageFile = files.find(file => file.endsWith('.png'));
+
+      if (!imageFile) {
+        return res.status(500).json({ error: 'No image generated' });
+      }
+
+      const imageUrl = `http://localhost:3000/generated_images/${imageFile}`;
+      res.json({ imageUrl });
+    });
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+*/ // Had to comment this out because I have to do OpenAI API stuff first before this.

--- a/backend/src/controllers/img-generation/openaiController.ts
+++ b/backend/src/controllers/img-generation/openaiController.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import axios from 'axios';
+
+export const generateImage = async (req: Request, res: Response): Promise<void> => {
+  const { prompt } = req.body;
+
+  if (!prompt) {
+    res.status(400).json({ error: 'Prompt is required' });
+    return; // Explicit return with void
+  }
+
+  try {
+    const response = await axios.post(
+      'https://api.openai.com/v1/images/generations',
+      {
+        prompt,
+        n: 1,
+        size: '1024x1024',
+      },
+      {
+        headers: {
+          'Authorization': `Bearer ${process.env.MY_OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    const imageUrl = response.data.data[0].url;
+    res.json({ imageUrl });
+  } catch (error: unknown) { 
+    if (axios.isAxiosError(error)) {
+      console.error('Error generating image:', {
+        message: error.message,
+        status: error.response?.status,
+        data: error.response?.data,
+      });
+      res.status(500).json({ 
+        error: 'Failed to generate image', 
+        details: error.response?.data || error.message 
+      });
+    } else {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`Error generating image: ${errorMessage}`);
+      res.status(500).json({ error: 'Failed to generate image' });
+    }
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import playerActivityRoutes from './routes/statistics/playerActivityRoutes'; // 
 import gameRoutes from './routes/game/gameRoutes';
 import { initializeModels } from './service/models';
 import paymentRoutes from './routes/transaction/shopRoutes';
+import openaiRoute from './routes/img-generation/openaiRoute'; // Image generation
 
 const PORT = process.env.PORT || 3000;
 const app = express();
@@ -53,6 +54,7 @@ app.use('/statistics/statsRoutes', statsRoutes); // Use the new stats route
 app.use('/statistics/playerActivityRoutes', playerActivityRoutes); // Use the new player activity route
 app.use('/game', gameRoutes);
 app.use('/payments', paymentRoutes);
+app.use('/openai', openaiRoute); // Image generation
 
 // Auth routes setup
 const authRouter = createAuthRouter(frontendUrl);

--- a/backend/src/routes/img-generation/openaiRoute.ts
+++ b/backend/src/routes/img-generation/openaiRoute.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { generateImage } from '../../controllers/img-generation/openaiController';
+
+const router = Router();
+
+router.post('/generate-image', generateImage);
+// Must put requestHandler on generateImage if still doesn't work later on.
+
+export default router;

--- a/backend/src/test.ts
+++ b/backend/src/test.ts
@@ -1,3 +1,0 @@
-// backend/src/test.ts
-import openaiRoute from './routes/img-generation/openaiRoute';
-console.log(openaiRoute);

--- a/backend/src/test.ts
+++ b/backend/src/test.ts
@@ -1,0 +1,3 @@
+// backend/src/test.ts
+import openaiRoute from './routes/img-generation/openaiRoute';
+console.log(openaiRoute);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,10 @@ import UserProfile from './profile/UserProfile';
 import GameScreen from './game/GameScreen';
 import GameDetails from './game-details/GameDetails';
 import Subscription from './subscription/Subscription';
+
+// Work in Progress Components [EXPERIMENTAL - Do not include in main app!]
+import ImageGeneratorScreen from './game/separate-imgGen/chatImgGeneration';
+
 // Game Creation Components
 import GameCreation from './game-creation/GameCreation';
 import AdventureEditor from './game-creation/Editing Page/Editor';
@@ -108,6 +112,9 @@ function App() {
             </ProtectedRoute>
           } 
         />
+
+        {/* Work in Progress Routes */}
+        <Route path="/image-generator" element={<ImageGeneratorScreen />} />
         
         {/* Utility Routes */}
         <Route path="/subscription" element={<Subscription />} />

--- a/frontend/src/game/GameScreen.tsx
+++ b/frontend/src/game/GameScreen.tsx
@@ -42,7 +42,7 @@ const GameScreen: React.FC = () => {
                     content: msg.content,
                     isUser: msg.role === 'user',
                     timestamp: new Date(msg.createdAt).toLocaleTimeString()
-                })); // No reverse here, keep oldest first
+                }));
                 setChatMessages(formattedMessages);
             } catch (error) {
                 console.error('Error fetching chat messages:', error);

--- a/frontend/src/game/separate-imgGen/chatImgGeneration.tsx
+++ b/frontend/src/game/separate-imgGen/chatImgGeneration.tsx
@@ -1,0 +1,126 @@
+import React, { useState, KeyboardEvent, useRef, useEffect } from 'react';
+import axiosInstance from '../../../config/axiosConfig';
+import Sidebar from '../../components/Sidebar';
+import GameHeader from '../../components/GameHeader';
+
+const ImageGeneratorScreen: React.FC = () => {
+    const [prompt, setPrompt] = useState('');
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState('');
+    const [showScroll, setShowScroll] = useState(false);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const chatContainerRef = useRef<HTMLDivElement>(null);
+    const [chatMessages, setChatMessages] = useState<Array<{ content: string, isUser: boolean, timestamp: string, imageUrl?: string }>>([]);
+
+    useEffect(() => {
+        if (chatContainerRef.current) {
+            chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight; // Scroll to bottom
+        }
+    }, [chatMessages]);
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleSubmit(e as any);
+        }
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError('');
+        setSuccess('');
+
+        if (!prompt.trim()) {
+            setError('Prompt cannot be empty.');
+            return;
+        }
+
+        const payload = {
+            prompt
+        };
+
+        try {
+            // Temporarily show user's prompt with current time
+            const tempUserMessage = {
+                content: prompt,
+                isUser: true,
+                timestamp: new Date().toLocaleTimeString()
+            };
+            setChatMessages(prevMessages => [...prevMessages, tempUserMessage]); // Append to bottom
+
+            const response = await axiosInstance.post('/openai/generate-image', payload);
+
+            const aiResponse = {
+                content: response.data.imageUrl || "Image generation failed.",
+                isUser: false,
+                timestamp: new Date().toLocaleTimeString(),
+                imageUrl: response.data.imageUrl
+            };
+
+            // Replace temp user message with backend data if available
+            setChatMessages(prevMessages => [...prevMessages.slice(0, -1), aiResponse]);
+
+            setSuccess('Image generated successfully!');
+            setPrompt('');
+        } catch (err) {
+            console.error('Error generating image:', err);
+            setError('An unexpected error occurred. Please try again.');
+        }
+    };
+
+    return (
+        <div className="min-h-screen bg-[#1E1E1E] text-[#E5D4B3] flex flex-col">
+            <GameHeader />
+            <Sidebar />
+            <br />
+            <br />
+            <br />
+            <div className="flex-grow flex justify-center items-center mt-[-5%]">
+                <div
+                    ref={chatContainerRef}
+                    className="bg- text-white w-full md:w-1/2 p-4 rounded mt-1 mx-auto overflow-y-auto max-h-[calc(1.5em*30)] scrollbar-hide"
+                    style={{ scrollbarColor: '#634630 #1E1E1E' }}
+                >
+                    {chatMessages.map((msg, index) => (
+                        <div key={index} className={`mb-4 ${msg.isUser ? 'text-right' : 'text-left'}`}>
+                            <p className={`inline-block p-2 rounded-lg ${msg.isUser ? 'bg-[#311F17] text-white' : 'bg-[#634630] text-[#E5D4B3]'}`}>
+                                {msg.content}
+                            </p>
+                            {msg.imageUrl && (
+                                <img src={msg.imageUrl} alt="Generated" className="max-w-full h-auto mt-2 rounded-lg" />
+                            )}
+                            <p className="text-xs text-gray-500 mt-1">{msg.timestamp}</p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+            <div className="w-full md:w-1/2 mx-auto mt-[0%] flex flex-col items-center md:items-start space-y-4 fixed bottom-0 md:relative md:bottom-auto bg-[#1E1E1E] md:bg-transparent p-4 md:p-0">
+                <div className="w-full flex items-start bg-[#311F17] rounded-2xl focus-within:outline-none">
+                    <textarea
+                        ref={textareaRef}
+                        className={`w-full p-4 rounded-l-2xl bg-transparent text-white font-playfair text-xl focus:outline-none resize-none min-h-[56px] max-h-48 ${
+                            showScroll ? 'overflow-y-auto scrollbar-thin scrollbar-thumb-[#634630] scrollbar-track-transparent' : 'overflow-y-hidden'
+                        }`}
+                        placeholder="Type your prompt here..."
+                        value={prompt}
+                        onChange={(e) => setPrompt(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        rows={1}
+                        style={{
+                            minHeight: '56px',
+                            height: `${Math.min(prompt.split('\n').length * 24 + 32, 192)}px`
+                        }}
+                    />
+                    <button className="p-4 bg-transparent rounded-r-2xl relative group self-start" onClick={handleSubmit}>
+                        <img src="/Enter.svg" alt="Enter" className="h-6 group-hover:opacity-0" />
+                        <img src="/Enter-after.svg" alt="Enter Hover" className="h-6 absolute top-4 left-4 opacity-0 group-hover:opacity-100" />
+                    </button>
+                </div>
+                {error && <p className="text-red-500 mt-2">{error}</p>}
+                {success && <p className="text-green-500 mt-2">{success}</p>}
+            </div>
+        </div>
+    );
+};
+
+export default ImageGeneratorScreen;


### PR DESCRIPTION
**### Backend**

**Task Given**: _Add Image Generation using OpenAI's DALL-E._ 
Files Created: `openaiController.ts`, `openaiRoute.ts`
Files Updated: `index.ts`

I created a folder related to image generation to manage the files. `src/controllers` and `src/routes` are among them, whereas `openaiController.ts`'s generateImage function is stored in handling the request in using OpenAI's DALL-E API, and a POST route to handle image generation request. I updated `index.ts` to include `openaiRoute.ts`.

> When testing the newly added Endpoint:
> - Tested the new endpoint using Postman to ensure images are generated correctly based on user prompts.
> - Verified that the endpoint returns appropriate error messages for invalid requests.

**### Frontend**

**Task Made**:  _Add & Integrate OpenAI's DALL-E Image Generation_
Files Created: `chatImgGeneration.tsx`
FIles Updated: `App.tsx`

Created a folder in `src/game` named `separate-imgGen` to make files and folders manageable. Inside the folder is the new screen for image generation with the same functionality as the chat or `GameScreen.tsx`, where as when you enter a prompt, it will reply an image. Since this feature is one of project's main objective, the current state is still experimental and has been separated in order to be updated in future progress.

> When testing the new screen:
> -Prompts are submitted correctly and images are displayed.